### PR TITLE
Update mbtiles dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "bluebird": "^3.4.6",
     "coffee-script": "^1.11.1",
-    "mbtiles": "^0.9.0",
+    "@mapbox/mbtiles": "^0.10.0",
     "node-protobuf": "^1.4.1",
     "split": "^1.0.0"
   }

--- a/src/TileGrinder.coffee
+++ b/src/TileGrinder.coffee
@@ -7,7 +7,7 @@
   and store them again.
 ###
 
-MBTiles = require 'mbtiles'
+MBTiles = require '@mapbox/mbtiles'
 Protobuf = require 'node-protobuf'
 Promise = require 'bluebird'
 split = require 'split'


### PR DESCRIPTION
I was getting compilation errors for sqlite3 on node v11 until I upgraded this dep, then it worked great.